### PR TITLE
Zuul: don't specify 'project.name'

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -1,6 +1,5 @@
 ---
 - project:
-    name: packit-service/packit-service-fedmsg
     check:
       jobs:
         - pre-commit


### PR DESCRIPTION
When zuul configuration is stored in the repository, this is not
required.

Signed-off-by: Hunor Csomortáni <csomh@redhat.com>