### PR TITLE
Support AWS SQS as a Celery broker

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,22 +4,24 @@
 
 repos:
   - repo: https://github.com/psf/black
-    rev: stable
+    rev: 20.8b1
     hooks:
       - id: black
-        language_version: python3.6
   - repo: https://github.com/prettier/prettier
-    rev: 2.0.5
+    rev: 2.1.1
     hooks:
       - id: prettier
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v3.1.0
+    rev: v3.2.0
     hooks:
       - id: check-added-large-files
       - id: check-ast
       - id: check-merge-conflict
       - id: check-yaml
       - id: detect-private-key
+      - id: detect-aws-credentials
+        args:
+          - --allow-missing-credentials
       - id: end-of-file-fixer
       - id: trailing-whitespace
   - repo: https://gitlab.com/pycqa/flake8
@@ -34,7 +36,7 @@ repos:
       - id: mypy
         args: [--no-strict-optional, --ignore-missing-imports]
   - repo: https://github.com/packit-service/pre-commit-hooks
-    rev: master
+    rev: 76dd54a98306a9f6ecf6672aa7687d6f07091c4e
     hooks:
       - id: check-rebase
         args:

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-IMAGE ?= usercont/packit-service-fedmsg:dev
+IMAGE ?= docker.io/usercont/packit-service-fedmsg:dev
 CONTAINER_ENGINE ?= docker
 ANSIBLE_PYTHON ?= /usr/bin/python3
 AP ?= ansible-playbook -vv -c local -i localhost, -e ansible_python_interpreter=$(ANSIBLE_PYTHON)
@@ -11,6 +11,7 @@ build: files/install-deps.yaml files/recipe.yaml
 run:
 	$(CONTAINER_ENGINE) run --rm \
 	    --env FEDORA_MESSAGING_CONF=/home/packit/.config/fedora.toml \
+	    --env REDIS_SERVICE_HOST=redis \
         -v $(CURDIR)/packit_service_fedmsg:/usr/local/lib/python3.7/site-packages/packit_service_fedmsg \
         -v $(CURDIR)/fedora.toml:/home/packit/.config/fedora.toml \
         --security-opt label=disable \

--- a/files/install-deps.yaml
+++ b/files/install-deps.yaml
@@ -8,6 +8,7 @@
           - python3-celery
           - python3-redis
           - redis # redis-cli
+          - python3-boto3 # AWS SDK
           - python3-click
           - git # setuptools-scm
           - fedora-messaging
@@ -17,5 +18,5 @@
     - name: Install pip deps
       pip:
         name:
-          - sentry-sdk==0.14.0
+          - sentry-sdk
         executable: pip3

--- a/setup.cfg
+++ b/setup.cfg
@@ -31,7 +31,7 @@ setup_requires =
     setuptools_scm_git_archive
 
 install_requires =
-    celery[redis]
+    celery[redis,sqs]
     fedora-messaging
     copr-messaging
     click


### PR DESCRIPTION
We use AWS SQS if both `AWS_ACCESS_KEY_ID` & `AWS_SECRET_ACCESS_KEY` are set.
It they are not, fall back to redis.
By default (if `QUEUE_NAME_PREFIX` is not set) we use `packit-$DEPLOYMENT-` queue prefix,
i.e. we have `packit-stg-celery` and `packit-prod-celery` queues.