### PR TITLE
Install pycurl explicitly

### DIFF
--- a/files/install-deps.yaml
+++ b/files/install-deps.yaml
@@ -6,9 +6,10 @@
       dnf:
         name:
           - python3-celery
-          - python3-redis
+          - python3-redis # celery[redis]
           - redis # redis-cli
-          - python3-boto3 # AWS SDK
+          - python3-boto3 # celery[sqs]
+          - python3-pycurl # celery[sqs]
           - python3-click
           - git # setuptools-scm
           - fedora-messaging


### PR DESCRIPTION
It's being pulled in probably with fedora-messaging, but better be explicit.