### PR TITLE
Packit namespace on GitHub has been renamed

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -33,10 +33,10 @@ repos:
       - id: mypy
         args: [--no-strict-optional, --ignore-missing-imports]
         additional_dependencies: [types-click]
-  - repo: https://github.com/packit-service/pre-commit-hooks
+  - repo: https://github.com/packit/pre-commit-hooks
     rev: 77d2c91b31c161ccf9fb3b4259606f000f374c33
     hooks:
       - id: check-rebase
         args:
-          - git://github.com/packit-service/packit-service-fedmsg.git
+          - git://github.com/packit/packit-service-fedmsg.git
         stages: [manual, push]


### PR DESCRIPTION
It was renamed from `packit-service` to `packit`.
Looks like forwarding still works, but we don't know for how long.

Signed-off-by: Frantisek Lachman <flachman@redhat.com>