### PR TITLE
Improve logs for all topics

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,11 +4,11 @@
 
 repos:
   - repo: https://github.com/psf/black
-    rev: 22.1.0
+    rev: 22.3.0
     hooks:
       - id: black
   - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: v2.5.1
+    rev: v2.6.1
     hooks:
       - id: prettier
   - repo: https://github.com/pre-commit/pre-commit-hooks
@@ -28,13 +28,13 @@ repos:
         args:
           - --max-line-length=100
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.931
+    rev: v0.942
     hooks:
       - id: mypy
         args: [--no-strict-optional, --ignore-missing-imports]
         additional_dependencies: [types-click]
   - repo: https://github.com/packit/pre-commit-hooks
-    rev: 1da916777f5cc26ecf221b15e58ca51891d26d94
+    rev: 3bf9afc5ede12a4ee26e9451f306edf255749396
     hooks:
       - id: check-rebase
         args:


### PR DESCRIPTION
To have more info in logs about the received message, we previously logged what we found in `message.body["what"]`.
The problem is that that key is present only in copr topics, which are the only topics we initially started with.
Since then we added more topics, so we need to check different keys for each topic if want to log what we actually consume.