### PR TITLE
Timezone-aware timestamp & environment files

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -17,7 +17,7 @@ jobs:
             image: packit-service-fedmsg
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Extract branch name and set tag
         shell: bash
@@ -32,9 +32,9 @@ jobs:
                   tag="prod"
                   ;;
           esac
-          echo "::set-output name=branch::${branch}"
+          echo "branch=${branch}" >> $GITHUB_OUTPUT
           unique_tag="${branch}-${GITHUB_SHA::7}"
-          echo "::set-output name=tag::${tag} ${unique_tag}"
+          echo "tag=${tag} ${unique_tag}" >> $GITHUB_OUTPUT
         id: branch_tag
 
       - name: Build Image

--- a/packit_service_fedmsg/consumer.py
+++ b/packit_service_fedmsg/consumer.py
@@ -1,7 +1,7 @@
 # Copyright Contributors to the Packit project.
 # SPDX-License-Identifier: MIT
 
-from datetime import datetime
+from datetime import datetime, timezone
 from functools import reduce
 from logging import getLogger
 from os import getenv
@@ -194,7 +194,7 @@ class Consumerino:
             logger.info(what)
 
         event["topic"] = topic
-        event["timestamp"] = datetime.utcnow().timestamp()
+        event["timestamp"] = datetime.now(timezone.utc).timestamp()
         result = self.celery_app.send_task(
             name="task.steve_jobs.process_message", kwargs={"event": event}
         )


### PR DESCRIPTION
Timezone-aware timestamp:
- https://stackoverflow.com/questions/62006348/why-datetime-now-and-datetime-utcnow-return-different-timestamp
- https://docs.sourcery.ai/Reference/Built-in-Rules/suggestions/aware-datetime-for-utc/

---

Environment files:
Related to packit/deployment#396
- https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
- https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter