### PR TITLE
Don't build the image using OCI metadata format

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -45,7 +45,8 @@ jobs:
           dockerfiles: ${{ matrix.dockerfile }}
           image: ${{ matrix.image }}
           tags: ${{ steps.branch_tag.outputs.tag }}
-          oci: true
+          # Uncomment once we stop using oc cluster up for tests
+          # oci: true
 
       - name: Push To Quay
         # https://github.com/marketplace/actions/push-to-registry


### PR DESCRIPTION
`oc cluster up` can't handle it

- https://github.com/marketplace/actions/buildah-build#inputs-for-build-from-containerfile
- https://github.com/packit/deployment/pull/455#issuecomment-1472469087