### PR TITLE
fix: property is cached now

### DIFF
--- a/packit_service_fedmsg/consumer.py
+++ b/packit_service_fedmsg/consumer.py
@@ -23,7 +23,6 @@ class Consumerino:
     """
 
     def __init__(self):
-        self._celery_app = None
         self.environment = getenv("DEPLOYMENT")
         self.packit_user = {"prod": "packit", "stg": "packit-stg"}.get(
             self.environment,
@@ -45,7 +44,7 @@ class Consumerino:
         # https://docs.celeryq.dev/en/latest/userguide/configuration.html#std-setting-task_default_queue
         _celery_app.conf.task_default_queue = "short-running"
 
-        return self._celery_app
+        return _celery_app
 
     @staticmethod
     def configure_sentry():


### PR DESCRIPTION
Oversee from the conversion of the property into a cached property. Attribute doesn't get set at all.

Fixes [PCKT-002-PACKIT-SERVICE-4XJ](https://red-hat-it.sentry.io/issues/3765895222/)