### PR TITLE
Skip the specfile changed check for PR pushes

### DIFF
--- a/packit_service_fedmsg/callbacks.py
+++ b/packit_service_fedmsg/callbacks.py
@@ -71,8 +71,13 @@ def _koji(topic: str, event: dict, packit_user: str) -> CallbackResult:
 
 
 def _fedora_dg_push(topic: str, event: dict, packit_user: str) -> CallbackResult:
-    if getenv("PROJECT", "").startswith("packit") and not specfile_changed(
-        event,
+    if (
+        getenv("PROJECT", "").startswith("packit")
+        # skip the specfile changed check for commits from PRs
+        and nested_get(event, "commit", "agent") != "pagure"
+        and not specfile_changed(
+            event,
+        )
     ):
         return CallbackResult(
             msg="[Fedora DG] No specfile change, ignoring the push.",


### PR DESCRIPTION
The check will be done later in the packit-service.

Related to packit/packit-service#2271