### PR TITLE
fix(deps): install ‹requests›

### DIFF
--- a/files/install-deps.yaml
+++ b/files/install-deps.yaml
@@ -9,6 +9,7 @@
           - git # setuptools-scm
           - fedora-messaging
           - python3-copr-messaging # json schemas
+          - python3-requests
         state: present
 
     - name: Install pip deps


### PR DESCRIPTION
During the production deployment on May 27th it has been discovered that the fedmsg pod on production entered crash loop backoff. After inspecting the logs it has been noticed that the ‹requests› package was gone. Therefore add it explicitly to the dependencies.

Related to packit/agile#552