### PR TITLE
fix: add ‹/usr/local› to ‹PYTHONPATH›

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,10 @@
 FROM quay.io/packit/base:c9s
+# [NOTE] Adjust ‹PYTHONPATH› when changing the default image
 
 ENV USER=packit \
     HOME=/home/packit \
+    # [NOTE] Fixes the issue with importing after upgrading Fedora Messaging to
+    # 3.5.0: fedora-infra/fedora-messaging#364
     PYTHONPATH="/usr/local/lib/python3.9/site-packages"
 
 COPY files/install-deps.yaml /src/files/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,8 @@
 FROM quay.io/packit/base:c9s
 
 ENV USER=packit \
-    HOME=/home/packit
+    HOME=/home/packit \
+    PYTHONPATH="/usr/local/lib/python3.9/site-packages"
 
 COPY files/install-deps.yaml /src/files/
 RUN cd /src/ \


### PR DESCRIPTION
With regards to the change that occured in between 3.4.1 and 3.5.0 releases of Fedora Messaging, it is not possible to import consumer callback from ‹/usr/local/› installed Python module, which is the default for global installation of packages via pip.

Given the fact that there needs to be hardcoded Python version in the path, I hate this solution.

When trying out ‹--callback-file›, I've been hit with the same import issue, as Celery is installed via pip too, cause it hasn't been released to EPEL9 even after a year of requesting this via RHBZ#2032543.

Trying out the “hack”¹ from similar project resulted in failure too, as the current working directory isn't included in the path either.

So much for the ecosystem and easy to use…

¹ https://gitlab.com/CentOS/Integration/gitlab-webhooks/-/merge_requests/1/diffs?commit_id=1bc3b2f8c2598dd6a24c70f149b3cc683eaf37b1

Related to fedora-infra/fedora-messaging#364

---

<!-- notes for reviewers -->
- follow-up from the Monday's deployment
