### PR TITLE
Adding callback for Log Detective

### DIFF
--- a/packit_service_fedmsg/callbacks.py
+++ b/packit_service_fedmsg/callbacks.py
@@ -226,6 +226,16 @@ def _openscanhub_task_started(
     )
 
 
+def _logdetective_analysis_result(
+    topic: str,
+    event: dict,
+    packit_user: str,
+) -> CallbackResult:
+    return CallbackResult(
+        msg=f"[LogDetective] analysis for {event.get('target_build')} is available.",
+    )
+
+
 # [WARNING]
 # Configuration of the topics to listen to needs to be changed in
 # a respective fedora.toml.j2 (https://github.com/packit/deployment/tree/main/secrets)
@@ -247,4 +257,5 @@ MAPPING = {
     "org.release-monitoring.prod.anitya.project.version.update.v2": _anitya_version_update,
     "org.fedoraproject.prod.openscanhub.task.started": _openscanhub_task_started,
     "org.fedoraproject.prod.openscanhub.task.finished": _openscanhub_task_finished,
+    "org.fedoraproject.prod.logdetective.analysis": _logdetective_analysis_result,
 }

--- a/tests/data/logdetective_analysis_result.json
+++ b/tests/data/logdetective_analysis_result.json
@@ -1,0 +1,42 @@
+{
+  "body": {
+    "log_detective_response": {
+      "explanation": {
+        "text": "The RPM build failed due to a test setup failure and a specific test case \"XXXX\" failing.\nThe overall result of the build process was also reported as FAIL.\nTo resolve this, investigate the test setup environment and the failing test case to identify the root cause.",
+        "logprobs": null
+      },
+      "response_certainty": 0.0,
+      "snippets": [
+        {
+          "explanation": {
+            "text": "The snippet indicates uncertainty about an event that occured during the build.",
+            "relevance": 95
+          },
+          "text": "What happened?",
+          "line_number": 0
+        },
+        {
+          "explanation": {
+            "text": "The log snippet indicates a generic failure during an RPM build process. The message 'Failure!' suggests that a command or script executed during the build returned a non-zero exit code, halting the process.",
+            "relevance": 95
+          },
+          "text": "Failure!",
+          "line_number": 0
+        }
+      ]
+    },
+    "target_build": "9999",
+    "build_system": "koji",
+    "result": "complete"
+  },
+  "headers": {
+    "fedora_messaging_schema": "base.message",
+    "fedora_messaging_severity": 20,
+    "priority": 0,
+    "sent-at": "2025-11-29T00:00:00+00:00"
+  },
+  "id": "197dc06b-3ae6-435a-93dc-baad4e39cda2",
+  "priority": 0,
+  "queue": null,
+  "topic": "org.fedoraproject.prod.logdetective.analysis"
+}

--- a/tests/test_log_detective_tasks.py
+++ b/tests/test_log_detective_tasks.py
@@ -1,0 +1,20 @@
+# Copyright Contributors to the Packit project.
+# SPDX-License-Identifier: MIT
+
+import json
+
+from celery import Celery
+from fedora_messaging import message
+from flexmock import flexmock
+
+from packit_service_fedmsg.consumer import Consumerino
+from tests.spellbook import DATA_DIR
+
+
+def test_tasks_event():
+    flexmock(Celery).should_receive("send_task").and_return(flexmock(id="a")).once()
+    with open(DATA_DIR / "logdetective_analysis_result.json") as outfile:
+        json_msg = json.load(outfile)
+        msg = message.loads(json.dumps(json_msg))
+        c = Consumerino()
+        c(msg[0])


### PR DESCRIPTION
<!-- TODO list -->

TODO:

- [x] Write new tests or update the old ones to cover new functionality.
- [x] Update doc-strings where appropriate.


Callback for messages produced by https://github.com/fedora-copr/logdetective-packit/ 

I do not expect the infrastructure on the side of packit-service to be available for some time yet.
However, merging this will have effectively no effect until requests from packit start coming in, and responses from Log Detective start coming back.

Schema for the message shouldn't change. Although, if necessary, we may yet release it as a package.

<!-- release notes footer -->

RELEASE NOTES BEGIN

Messages from Log Detective, under the `org.fedoraproject.prod.logdetective.analysis` topic are now processed by a callback. 

RELEASE NOTES END
