### PR TITLE
Pin GitHub Actions to commit hashes for security

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -18,7 +18,7 @@ jobs:
             image: packit-service-fedmsg
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
 
       - name: Extract branch name and set tag
         shell: bash
@@ -41,7 +41,7 @@ jobs:
       - name: Build Image
         id: build-image
         # https://github.com/marketplace/actions/buildah-build
-        uses: redhat-actions/buildah-build@v2
+        uses: redhat-actions/buildah-build@7a95fa7ee0f02d552a32753e7414641a04307056 # v2
         with:
           dockerfiles: ${{ matrix.dockerfile }}
           image: ${{ matrix.image }}
@@ -51,7 +51,7 @@ jobs:
 
       - name: Push To Quay
         # https://github.com/marketplace/actions/push-to-registry
-        uses: redhat-actions/push-to-registry@v2
+        uses: redhat-actions/push-to-registry@5ed88d269cf581ea9ef6dd6806d01562096bee9c # v2
         with:
           image: ${{ steps.build-image.outputs.image }}
           tags: ${{ steps.build-image.outputs.tags }}

--- a/.github/workflows/check-release-notes.yml
+++ b/.github/workflows/check-release-notes.yml
@@ -10,6 +10,6 @@ on:
 jobs:
   check_release_notes:
     name: Notes are either written, or there are none
-    uses: packit/.github/.github/workflows/check-release-notes.yml@main
+    uses: packit/.github/.github/workflows/check-release-notes.yml@2837c96caf71966609451ad0323552ef4be11a23
     with:
       description: ${{ github.event.pull_request.body }}


### PR DESCRIPTION
Pin all actions to specific commit SHAs to prevent supply chain attacks and ensure reproducible builds.

Assisted-By: Claude Sonnet 4.5 <noreply@anthropic.com>